### PR TITLE
Add MIDI support

### DIFF
--- a/src/audio/synth.js
+++ b/src/audio/synth.js
@@ -36,6 +36,9 @@ class Synth {
 
     // Set initial master volume
     this.masterGain.gain.value = 0.75;
+
+    // Initialize MIDI
+    this.initMIDI();
   }
 
   createPhaser() {
@@ -167,6 +170,41 @@ class Synth {
 
   getPhaseScopeData() {
     return this.getAnalyzerData(this.phaseScopeAnalyzer, true);
+  }
+
+  initMIDI() {
+    if (navigator.requestMIDIAccess) {
+      navigator.requestMIDIAccess().then(
+        (midiAccess) => {
+          for (let input of midiAccess.inputs.values()) {
+            input.onmidimessage = this.handleMIDIMessage.bind(this);
+          }
+        },
+        (err) => {
+          console.error('Failed to get MIDI access', err);
+        }
+      );
+    } else {
+      console.warn('MIDI not supported in this browser.');
+    }
+  }
+
+  handleMIDIMessage(event) {
+    const [command, note, velocity] = event.data;
+    switch (command) {
+      case 144: // Note on
+        if (velocity > 0) {
+          this.noteOn(note);
+        } else {
+          this.noteOff(note);
+        }
+        break;
+      case 128: // Note off
+        this.noteOff(note);
+        break;
+      default:
+        break;
+    }
   }
 }
 

--- a/src/components/Keyboard.vue
+++ b/src/components/Keyboard.vue
@@ -134,9 +134,45 @@ const handleKeyUp = (event) => {
   }
 }
 
+const initMIDI = () => {
+  if (navigator.requestMIDIAccess) {
+    navigator.requestMIDIAccess().then(
+      (midiAccess) => {
+        for (let input of midiAccess.inputs.values()) {
+          input.onmidimessage = handleMIDIMessage
+        }
+      },
+      (err) => {
+        console.error('Failed to get MIDI access', err)
+      }
+    )
+  } else {
+    console.warn('MIDI not supported in this browser.')
+  }
+}
+
+const handleMIDIMessage = (event) => {
+  const [command, note, velocity] = event.data
+  switch (command) {
+    case 144: // Note on
+      if (velocity > 0) {
+        handleNoteOn(note)
+      } else {
+        handleNoteOff(note)
+      }
+      break
+    case 128: // Note off
+      handleNoteOff(note)
+      break
+    default:
+      break
+  }
+}
+
 onMounted(() => {
   window.addEventListener('keydown', handleKeyDown)
   window.addEventListener('keyup', handleKeyUp)
+  initMIDI()
 })
 
 onUnmounted(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import './style.css'
+import { initMIDI } from './components/Keyboard.vue'
 
 createApp(App).mount('#app')
+
+initMIDI()


### PR DESCRIPTION
Fixes #2

Add MIDI support to the application.

* **src/audio/synth.js**
  - Add `initMIDI` method to `Synth` class to initialize MIDI input.
  - Add `handleMIDIMessage` method to `Synth` class to handle MIDI messages.
  - Call `initMIDI` method in `createSynth` function to initialize MIDI.

* **src/components/Keyboard.vue**
  - Add `initMIDI` method to initialize MIDI input in `setup` function.
  - Add `handleMIDIMessage` method to handle MIDI messages in `setup` function.
  - Call `initMIDI` method in `onMounted` lifecycle hook.

* **src/main.js**
  - Import and call `initMIDI` method from `Keyboard.vue` to initialize MIDI.

---

For more details, open the [Copilot Workspace session](https://workspace.githubapp.com/mortenp1337/EMapp/issues/2?shareId=XXXX-XXXX-XXXX-XXXX).